### PR TITLE
ltt_install_torch installs wrong version of pytorch, and simple_enunu.py assigns an inappropriate device

### DIFF
--- a/enulib/install_torch.py
+++ b/enulib/install_torch.py
@@ -32,9 +32,9 @@ PYTORCH_PACKAGES_DICT = {
     # CUDA 11
     'release 11.': r'torch==1.13.1+cu117 torchvision==0.14.1+cu117 torchaudio==0.13.1 --extra-index-url https://download.pytorch.org/whl/cu117',
     # CUDA 10
-    'release 10.': r'torch==1.13.1+cu102 torchvision==0.14.1+cu102 torchaudio==0.13.1 --extra-index-url https://download.pytorch.org/whl/cu102',
+    'release 10.': r'torch==1.10.1+cu102 torchvision==0.11.2+cu102 torchaudio==0.10.1 --extra-index-url https://download.pytorch.org/whl/cu102',
     # no CUDA
-    'cpu': r'torch==1.13.1+cu102 torchvision==0.14.1+cu102 torchaudio==0.13.1'
+    'cpu': r'torch==1.13.1 torchvision==0.14.1 torchaudio==0.13.1'
 }
 
 
@@ -97,7 +97,7 @@ def main():
     """
     if input('インストールされているpytorchを上書きしてもいいですか？(YES/NO): ') == 'YES':
         ltt_install_torch(abspath(sys.executable))
-
+#        pip_install_torch(abspath(sys.executable))
 
 if __name__ == '__main__':
     main()

--- a/simple_enunu.py
+++ b/simple_enunu.py
@@ -41,18 +41,19 @@ sys.path.append(dirname(__file__))
 import enulib
 
 try:
-    import torch as _
+    import torch
 except ModuleNotFoundError:
     print('----------------------------------------------------------')
     print('初回起動ですね。')
     print('PC環境に合わせてPyTorchを自動インストールします。')
     print('インストール完了までしばらくお待ちください。')
     print('----------------------------------------------------------')
-    enulib.install_torch.ltt_install_torch(sys.executable)
+#    enulib.install_torch.ltt_install_torch(sys.executable)
+    enulib.install_torch.pip_install_torch(abspath(sys.executable))
     print('----------------------------------------------------------')
     print('インストール成功しました。')
     print('----------------------------------------------------------\n')
-    import torch as _
+    import torch
 
 # NNSVSをimportできるようにする
 if exists(join(dirname(__file__), 'nnsvs-master')):
@@ -194,7 +195,7 @@ def main(path_plugin: str, path_wav: Union[str, None] = None, play_wav=True) -> 
 
     # モデルを読み取る
     logging.info('Loading models')
-    engine = SPSVS(model_dir)
+    engine = SPSVS(model_dir, device="cuda" if torch.cuda.is_available() else "cpu")
     config = engine.config
 
     # UST → LAB の変換をする


### PR DESCRIPTION
Currently SimpleEnunu can't handle CUDA for three reason.

(1)ltt_install_torch does not install CUDA version of pytorch
(2)There are some mistakes in the table referred by pip_install_torch
(3)SPSVS class is instantiated without device assignment

This PR will fix them and enable to use CUDA.
